### PR TITLE
cloudconfig: Use yaml.safe_load to avoid deprecation warning

### DIFF
--- a/scripts/libvirt/cloudconfig.py
+++ b/scripts/libvirt/cloudconfig.py
@@ -66,7 +66,7 @@ def generateNetworkData():
 def generateUserdata(hostname, sshPrivateKeyfile, sshPublicKeyfile):
     # start w/ template
     template = open("scripts/libvirt/cloud-init-template.cls", "r")
-    userdata = yaml.load(template)
+    userdata = yaml.safe_load(template)
     template.close()
 
     userdata["hostname"] = hostname


### PR DESCRIPTION
The plain yaml.load interface has been deprecated
for security reasons, so use safe_load instead.
At least based on initial tests running cluster.install
/ cluster.destroy, things still work with the safe
YAML parser.

For details on the deprecation, see:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Signed-off-by: Kristoffer Grönlund <kgronlund@suse.com>