### PR TITLE
Remove `set -u` from _default-dev-settings.

### DIFF
--- a/_default-dev-settings
+++ b/_default-dev-settings
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -u
 
 #------------------#
 # Cluster settings #


### PR DESCRIPTION
Sometimes it's useful to source in the developer settings
(e.g. use `kubectl` without ssh'ing to the k8s master.

For example, shell tab complete is broken:

$ . developer-settings
$ -bash: _xspecs[$cmd]: unbound variable
$ make rook.-bash: !ref: unbound variable

Signed-off-by: Michael Fritch <mfritch@suse.com>