### PR TITLE
'/usr/bin/bash' does not exist on k8s

### DIFF
--- a/scripts/rook/wipe-disks.sh
+++ b/scripts/rook/wipe-disks.sh
@@ -3,6 +3,8 @@
 
 source scripts/shared.sh
 
+echo 'WIPE CEPH DISKS'
+
 # disk wiping is complicated, so copy the script to the nodes, then execute that
 ${OCTOPUS} --host-groups all copy scripts/rook/rook-disk-wipe-runner.sh /root
-${OCTOPUS} --host-groups all run "${BASH} /root/rook-disk-wipe-runner.sh"
+${OCTOPUS} --host-groups all run "/root/rook-disk-wipe-runner.sh"


### PR DESCRIPTION
The ${BASH} var passed to OCTOPUS is set to '/usr/bin/bash'.

This path does not exist on the k8s master/workers nodes, causing the
wipe-disks section of 'make rook.uninstall' to fail.

Signed-off-by: Michael Fritch <mfritch@suse.com>