### PR TITLE
'BASHCMD' does not exist

### DIFF
--- a/scripts/rook/install-filesystem.sh
+++ b/scripts/rook/install-filesystem.sh
@@ -26,7 +26,7 @@ echo 'SMOKE TESTING CEPHFS'
 
 
 # Mount the FS in the tools container, create a file, then unmount and exit
-kubectl exec -n "${ROOK_NAMESPACE}" "${toolbox_pod}" -- ${BASHCMD} -c "$(cat <<'EOF'
+kubectl exec -n "${ROOK_NAMESPACE}" "${toolbox_pod}" -- ${BASH_CMD} -c "$(cat <<'EOF'
 # Create dir for our
 mkdir /tmp/cephfs
 


### PR DESCRIPTION
Minor fixup to change 'BASHCMD' -> 'BASH_CMD'

Signed-off-by: Michael Fritch <mfritch@suse.com>